### PR TITLE
fix

### DIFF
--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from "next/server"
 import { getCurrentUser } from "@/lib/auth"
 import { getUserReservations } from "@/lib/database"
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     const user = await getCurrentUser()

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -6,7 +6,7 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getCurrentUser()
+    const user = await getCurrentUser(request)
     if (!user) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
+import { NextRequest } from "next/server"
 
 export async function createServerClient() {
   const cookieStore = cookies()
@@ -7,10 +8,35 @@ export async function createServerClient() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
 }
 
-export async function getCurrentUser() {
-  const supabase = await createServerClient()
+// export async function getCurrentUser() {
+//   const supabase = await createServerClient()
+//   const {
+//     data: { user },
+//   } = await supabase.auth.getUser()
+//   return user
+// }
+
+export async function getCurrentUser(request: NextRequest) {
+  const token = request.cookies.get('sb-access-token')?.value ||
+                request.cookies.get('supabase-auth-token')?.value
+  
+  if (!token) {
+    return null
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!, 
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+  
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+    error
+  } = await supabase.auth.getUser(token)
+  
+  if (error) {
+    return null
+  }
+  
   return user
 }


### PR DESCRIPTION
デプロイ時のエラーに対応
`export const dynamic = 'force-dynamic'`を追加

```Error: Dynamic server usage: Route /api/reservations couldn't be rendered statically because it used "cookies".
description: Route "/api/reservations" couldn't be rendered statically because it used "cookies". 
See more info here: https://nextjs.org/docs/messages/dynamic-server-usage
digest: DYNAMIC_SERVER_USAGE
```